### PR TITLE
Feat : quantity count button

### DIFF
--- a/src/components/button/CountButton.tsx
+++ b/src/components/button/CountButton.tsx
@@ -2,18 +2,39 @@ import React from "react";
 import { ReactComponent as MinusSVG } from "@assets/icon-minus-line.svg";
 import { ReactComponent as PlusSVG } from "@assets/icon-plus-line.svg";
 
-export const MinusCountButton = () => {
+interface CountButtonProps {
+  disabled: boolean;
+  onclick: () => void;
+}
+
+export const MinusCountButton = ({ disabled, onclick }: CountButtonProps) => {
   return (
-    <button type="button" className="border-r b-disabled-gray">
-      <MinusSVG className="mx-auto" stroke={"#C4C4C4"} />
+    <button
+      type="button"
+      onClick={onclick}
+      disabled={disabled}
+      className="border-r b-disabled-gray"
+    >
+      <MinusSVG
+        className="mx-auto"
+        stroke={`${disabled ? "#C4C4C4" : "#767676"}`}
+      />
     </button>
   );
 };
 
-export const PlusCountButton = () => {
+export const PlusCountButton = ({ disabled, onclick }: CountButtonProps) => {
   return (
-    <button type="button" className="border-l b-disabled-gray">
-      <PlusSVG className="mx-auto" stroke={"#C4C4C4"} />
+    <button
+      type="button"
+      onClick={onclick}
+      disabled={disabled}
+      className="border-l b-disabled-gray"
+    >
+      <PlusSVG
+        className="mx-auto"
+        stroke={`${disabled ? "#C4C4C4" : "#767676"}`}
+      />
     </button>
   );
 };

--- a/src/components/button/QuantityButtonBox.tsx
+++ b/src/components/button/QuantityButtonBox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   MinusCountButton,
   PlusCountButton,
@@ -20,16 +20,19 @@ const QuantityButtonBox = ({
     stock > 0 && refCount <= stock
   );
 
+  // 재고(stock) 또는 초기 수량(refCount) 값이 변경될 때 countUpState 업데이트
+  useEffect(() => {
+    setCountUpState(stock > 0 && quantity < stock);
+  }, [stock, quantity]);
+
   const onCountUp = () => {
     if (!countUpState) return;
     const plusCount = quantity + 1;
-    if (plusCount >= stock) setCountUpState(false);
     handelCountValue(plusCount);
   };
 
   const onCountDown = () => {
     const minusCount = quantity <= 1 ? 1 : quantity - 1;
-    if (!countUpState && minusCount <= stock) setCountUpState(true);
     handelCountValue(minusCount);
   };
 

--- a/src/components/button/QuantityButtonBox.tsx
+++ b/src/components/button/QuantityButtonBox.tsx
@@ -1,15 +1,50 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   MinusCountButton,
   PlusCountButton,
 } from "@components/button/CountButton";
 
-const QuantityButtonBox = () => {
+interface QuantityButtonBoxProps {
+  stock: number;
+  refCount?: number;
+  getProductCount?: (num: number) => void;
+}
+
+const QuantityButtonBox = ({
+  refCount = 0,
+  stock,
+  getProductCount,
+}: QuantityButtonBoxProps) => {
+  const [quantity, setQuantity] = useState(refCount || 1);
+  const [countUpState, setCountUpState] = useState(
+    stock > 0 && refCount <= stock
+  );
+
+  const onCountUp = () => {
+    if (!countUpState) return;
+    const plusCount = quantity + 1;
+    if (plusCount >= stock) setCountUpState(false);
+    handelCountValue(plusCount);
+  };
+
+  const onCountDown = () => {
+    const minusCount = quantity <= 1 ? 1 : quantity - 1;
+    if (!countUpState && minusCount <= stock) setCountUpState(true);
+    handelCountValue(minusCount);
+  };
+
+  const handelCountValue = (count: number) => {
+    setQuantity(count);
+    getProductCount?.(count);
+  };
+
   return (
     <div className="grid grid-cols-3 w-[15rem] border b-disabled-gray rounded-lg">
-      <MinusCountButton />
-      <span className="text-center text-[1.8rem] leading-[5rem]">1</span>
-      <PlusCountButton />
+      <MinusCountButton onclick={onCountDown} disabled={quantity <= 1} />
+      <span className="text-center text-[1.8rem] leading-[5rem]">
+        {!stock ? 0 : quantity}
+      </span>
+      <PlusCountButton onclick={onCountUp} disabled={!countUpState} />
     </div>
   );
 };

--- a/src/components/details/DetailUiGroup.tsx
+++ b/src/components/details/DetailUiGroup.tsx
@@ -6,34 +6,45 @@ import ProductCount from "@components/details/ProductCount";
 import { CommonButton } from "@components/button/CommonButton";
 
 interface DetailUiGroupProps {
-  disabled?: boolean;
+  disabled: boolean;
+  count: number;
+  getProductCount: (num: number) => void;
 }
 
-const DetailUiGroup = ({ disabled }: DetailUiGroupProps) => {
+const DetailUiGroup = ({ ...props }: DetailUiGroupProps) => {
   const { detail } = useAppSelector(getDetailState);
 
   return (
     <div className="grid w-full grid-cols-2 gap-16 max-[700px]:grid-cols-1">
-      {/* 상품 이미지 */}
-      <div className="w-full relative rounded-3xl overflow-hidden before:block before:pb-[100%] before:bg-light-gray">
-        <img
-          src={detail?.image}
-          alt="상품 대표이미지"
-          className="absolute top-0 object-cover w-full h-full"
-        />
-      </div>
-
-      {/* 상품 정보 */}
-      <div className="flex flex-col justify-between">
-        <ProductDetail />
-        <div className="flex flex-col gap-[2vh] border-t-2 b-disabled-gray pt-[2vh]">
-          <ProductCount />
-          <div className="grid grid-cols-[2fr_1fr] gap-5">
-            <CommonButton disabled={disabled}>바로 구매</CommonButton>
-            <CommonButton disabled={disabled}>장바구니</CommonButton>
+      {detail && (
+        <>
+          {/* 상품 이미지 */}
+          <div className="w-full relative rounded-3xl overflow-hidden before:block before:pb-[100%] before:bg-light-gray">
+            <img
+              src={detail?.image}
+              alt="상품 대표이미지"
+              className="absolute top-0 object-cover w-full h-full"
+            />
           </div>
-        </div>
-      </div>
+
+          {/* 상품 정보 */}
+          <div className="flex flex-col justify-between">
+            <ProductDetail />
+            <div className="flex flex-col gap-[2vh] border-t-2 b-disabled-gray pt-[2vh]">
+              <ProductCount
+                count={props.count}
+                getProductCount={props.getProductCount}
+                price={detail?.price}
+                stock={detail?.stock}
+              />
+              <div className="grid grid-cols-[2fr_1fr] gap-5">
+                <CommonButton disabled={props.disabled}>바로 구매</CommonButton>
+                <CommonButton disabled={props.disabled}>장바구니</CommonButton>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/details/ProductCount.tsx
+++ b/src/components/details/ProductCount.tsx
@@ -1,18 +1,29 @@
 import React from "react";
 import QuantityButtonBox from "@components/button/QuantityButtonBox";
 
-const ProductCount = () => {
+interface ProductCountProps {
+  count: number;
+  price: number;
+  stock: number;
+  getProductCount: (num: number) => void;
+}
+
+const ProductCount = ({ count, price, ...props }: ProductCountProps) => {
   return (
     <>
-      <QuantityButtonBox />
+      <QuantityButtonBox
+        getProductCount={props.getProductCount}
+        stock={props.stock}
+      />
       <div className="flex justify-between items-center border-t-2 b-disabled-gray text-[1.8rem] pt-8">
         <p className="font-medium">총 상품 금액</p>
         <div className="flex items-center text-main-choco">
           <p className="text-dark-gray after:content-['|'] after:px-4 after:text-disabled-gray">
-            총 수량 <span className="font-bold text-main-choco">1</span>개
+            총 수량 <span className="font-bold text-main-choco">{count}</span>개
           </p>
           <strong className="text-[3rem]">
-            17,500<span className="pl-1 font-normal">원</span>
+            {price && (price * count).toLocaleString("ko-KR")}
+            <span className="pl-1 font-normal">원</span>
           </strong>
         </div>
       </div>

--- a/src/pages/Detail/Detail.tsx
+++ b/src/pages/Detail/Detail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "@hooks/hooks";
 import { getLoginUserType, getToken } from "@store/slice/loginSlice";
@@ -14,22 +14,27 @@ const Detail = () => {
   const userType = useAppSelector(getLoginUserType);
   const { detail } = useAppSelector(getDetailState);
 
+  const [count, setCount] = useState(1);
+
   useEffect(() => {
     dispatch(fetchProductDetail(Number(productId)));
     window.scrollTo(0, 0);
   }, []);
 
   const disableButton = userType === "SELLER" || detail?.stock === 0;
+  const getProductCount = (num: number) => setCount(num);
 
   return (
     <div className="max-w-[138rem] mx-auto my-[8.6rem] px-16 pt-24">
-      {detail && (
-        <section>
-          <h2 className="sr-only">상품 디테일 페이지 UI</h2>
-          <DetailUiGroup disabled={disableButton} />
-          <DetailTab />
-        </section>
-      )}
+      <section>
+        <h2 className="sr-only">상품 디테일 페이지 UI</h2>
+        <DetailUiGroup
+          disabled={disableButton}
+          count={count}
+          getProductCount={getProductCount}
+        />
+        <DetailTab />
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
# Feat : quantity count button

## 🐶 무엇을 위한 PR인가요?
- [x] 기능 추가 : 상품 디테일 페이지 수량 카운트 버튼 구현
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

## ⚠️ 삭제된 파일 

- 없음

## ✂️ 수정된 파일

- src/components/button/CountButton.tsx
- src/components/button/QuantityButtonBox.tsx
- src/components/details/ProductCount.tsx
- src/components/details/DetailUiGroup.tsx
- src/pages/Detail/Detail.tsx

## 📝 생성된 파일

- 없음

## 🐶 스크린샷
<img width="864" alt="image" src="https://github.com/ming-Jo/KONG-Market/assets/112460344/c72d2144-dfd2-4092-be30-c75410d27c58">
<img width="869" alt="image" src="https://github.com/ming-Jo/KONG-Market/assets/112460344/5e234bc5-2843-4403-8593-fe4e5bd48c1b">


## 🐶 Issue Number
#12 

## 🐶 메모할 내용
- 재고가 1개 이상일 경우 : 재고 수량까지 Plus 버튼 가능 / 재고와 카운트가 같아지면 Plus 버튼 비활성화
- 재고가 0개 혹은 1개일 경우 : Plus, Minus 버튼 모두 비활성화


